### PR TITLE
DD-1492. Added more validators.

### DIFF
--- a/src/main/java/nl/knaw/dans/validation/AtLeastOneOf.java
+++ b/src/main/java/nl/knaw/dans/validation/AtLeastOneOf.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.validation;
+
+import javax.validation.Constraint;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = AtLeastOneOfValidator.class)
+@Documented
+public @interface AtLeastOneOf {
+    String message() default "At least one of the fields {fields} must be non-null";
+
+    Class<?>[] groups() default {};
+    
+    Class<?>[] payload() default {};
+    
+    String[] fields();
+}

--- a/src/main/java/nl/knaw/dans/validation/AtLeastOneOfValidator.java
+++ b/src/main/java/nl/knaw/dans/validation/AtLeastOneOfValidator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class AtLeastOneOfValidator implements ConstraintValidator<AtLeastOneOf, Object> {
+
+    private String[] fields;
+
+    @Override
+    public void initialize(AtLeastOneOf constraintAnnotation) {
+        fields = constraintAnnotation.fields();
+    }
+
+    @Override
+    public boolean isValid(Object object, ConstraintValidatorContext context) {
+        var nonNullFound = false;
+        for (String field : fields) {
+            try {
+                var fieldInstance = object.getClass().getDeclaredField(field);
+                fieldInstance.setAccessible(true);
+                if (fieldInstance.get(object) != null) {
+                    nonNullFound = true;
+                }
+            }
+            catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new IllegalStateException("Programming error: field " + field + " does not exist or is not accessible");
+            }
+        }
+        return nonNullFound;
+    }
+}

--- a/src/main/java/nl/knaw/dans/validation/MutuallyExclusive.java
+++ b/src/main/java/nl/knaw/dans/validation/MutuallyExclusive.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.validation;
+
+import javax.validation.Constraint;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MutuallyExclusiveValidator.class)
+@Documented
+public @interface MutuallyExclusive {
+    String message() default "The fields {fields} are mutually exclusive";
+
+    Class<?>[] groups() default {};
+
+    Class<?>[] payload() default {};
+
+    String[] fields();
+}

--- a/src/main/java/nl/knaw/dans/validation/MutuallyExclusiveValidator.java
+++ b/src/main/java/nl/knaw/dans/validation/MutuallyExclusiveValidator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class MutuallyExclusiveValidator implements ConstraintValidator<MutuallyExclusive, Object> {
+    private String[] fields;
+
+    @Override
+    public void initialize(MutuallyExclusive constraintAnnotation) {
+        fields = constraintAnnotation.fields();
+    }
+
+    @Override
+    public boolean isValid(Object object, ConstraintValidatorContext context) {
+        int count = 0;
+        for (String field : fields) {
+            try {
+                var fieldInstance = object.getClass().getDeclaredField(field);
+                fieldInstance.setAccessible(true);
+                if (fieldInstance.get(object) != null) {
+                    count++;
+                }
+            }
+            catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new IllegalStateException("Programming error: field " + field + " does not exist or is not accessible");
+            }
+        }
+        return count <= 1;
+    }
+}

--- a/src/main/java/nl/knaw/dans/validation/SwordToken.java
+++ b/src/main/java/nl/knaw/dans/validation/SwordToken.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.validation;
+
+import javax.validation.Constraint;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = SwordTokenValidator.class)
+@Documented
+public @interface SwordToken {
+    String message() default "Invalid SWORD token";
+
+    Class<?>[] groups() default {};
+
+    Class<?>[] payload() default {};
+}

--- a/src/main/java/nl/knaw/dans/validation/SwordToken.java
+++ b/src/main/java/nl/knaw/dans/validation/SwordToken.java
@@ -22,7 +22,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target({ ElementType.FIELD })
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = SwordTokenValidator.class)
 @Documented

--- a/src/main/java/nl/knaw/dans/validation/SwordTokenValidator.java
+++ b/src/main/java/nl/knaw/dans/validation/SwordTokenValidator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.validation;
+
+import javax.validation.ConstraintValidator;
+
+public class SwordTokenValidator implements ConstraintValidator<SwordToken, String> {
+    private static final String PREFIX = "sword:";
+
+    @Override
+    public boolean isValid(String value, javax.validation.ConstraintValidatorContext context) {
+        return value == null || isValidSwordToken(value, context);
+    }
+
+    private boolean isValidSwordToken(String value, javax.validation.ConstraintValidatorContext context) {
+        if (value.startsWith(PREFIX) && new UuidValidator().isValid(value.substring(PREFIX.length()), context)) {
+            return true;
+        }
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(getErrorMessage(value))
+            .addConstraintViolation();
+        return false;
+    }
+
+    private String getErrorMessage(String value) {
+        return value.startsWith(PREFIX) ? "SWORD token must contain a valid UUID after the 'sword:' prefix" : "SWORD token must start with 'sword:' prefix";
+    }
+}

--- a/src/main/java/nl/knaw/dans/validation/UrnUuid.java
+++ b/src/main/java/nl/knaw/dans/validation/UrnUuid.java
@@ -22,11 +22,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Constraint(validatedBy = UrnUuidValidator.class)
-@Target({ ElementType.FIELD, ElementType.PARAMETER})
+@Constraint(validatedBy = { UrnUuidValidator.class, UrnUuidValidatorForUri.class })
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface UrnUuid {
     String message() default "Invalid urn:uuid";
+
     Class<?>[] groups() default {};
+
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/nl/knaw/dans/validation/UrnUuidValidatorForUri.java
+++ b/src/main/java/nl/knaw/dans/validation/UrnUuidValidatorForUri.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.net.URI;
+import java.util.UUID;
+
+public class UrnUuidValidatorForUri implements ConstraintValidator<UrnUuid, URI> {
+
+    @Override
+    public boolean isValid(URI uri, ConstraintValidatorContext constraintValidatorContext) {
+        if (uri != null) {
+            if (!uri.getScheme().equals("urn")) {
+                return false;
+            }
+            if (!uri.getSchemeSpecificPart().startsWith("uuid:")) {
+                return false;
+            }
+            try {
+                UUID.fromString(uri.getSchemeSpecificPart().substring("uuid:".length()));
+            }
+            catch (IllegalArgumentException e) {
+                return false;
+            }
+        }
+        return true; // If null is not allowed, this should be checked by the @NotNull annotation
+    }
+}

--- a/src/test/java/nl/knaw/dans/validation/AtLeastOneOfTest.java
+++ b/src/test/java/nl/knaw/dans/validation/AtLeastOneOfTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.validation;
+
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.ValidationException;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AtLeastOneOfTest {
+
+    @AtLeastOneOf(fields = { "field1", "field2" })
+    private static class TestObject {
+        private String field1;
+        private String field2;
+    }
+
+    @AtLeastOneOf(fields = { "field1", "fieldXXX" })
+    private static class TestObjectMisconfigured {
+        private String field1;
+        private String field2;
+    }
+
+    @Test
+    public void should_return_true_when_one_of_two_fields_is_not_null() {
+        var testObject = new TestObject();
+        testObject.field1 = "value";
+        testObject.field2 = null;
+
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = factory.getValidator();
+            Set<ConstraintViolation<TestObject>> violations = validator.validate(testObject);
+
+            assertThat(violations).isEmpty();
+        }
+    }
+
+    @Test
+    public void should_return_true_when_two_of_two_fields_are_non_null() {
+        var testObject = new TestObject();
+        testObject.field1 = "value";
+        testObject.field2 = "value";
+
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = factory.getValidator();
+            Set<ConstraintViolation<TestObject>> violations = validator.validate(testObject);
+
+            assertThat(violations).isEmpty();
+        }
+    }
+
+    @Test
+    public void should_return_false_when_two_of_two_fields_are_null() {
+        var testObject = new TestObject();
+
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = factory.getValidator();
+            Set<ConstraintViolation<TestObject>> violations = validator.validate(testObject);
+
+            assertThat(violations).hasSize(1);
+            assertThat(violations).allMatch(v -> v.getMessage().equals("At least one of the fields [field1, field2] must be non-null"));
+        }
+    }
+
+    @Test
+    public void should_return_false_when_all_fields_are_null() {
+        var testObject = new TestObject();
+        testObject.field1 = null;
+        testObject.field2 = null;
+
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = factory.getValidator();
+            Set<ConstraintViolation<TestObject>> violations = validator.validate(testObject);
+
+            assertThat(violations).hasSize(1);
+            assertThat(violations).allMatch(v -> v.getMessage().equals("At least one of the fields [field1, field2] must be non-null"));
+        }
+    }
+
+    @Test
+    public void should_throw_exception_when_field_does_not_exist() {
+        var testObject = new TestObjectMisconfigured();
+        testObject.field1 = "value";
+
+        var exception = assertThrows(ValidationException.class, () -> {
+            try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+                Validator validator = factory.getValidator();
+                validator.validate(testObject);
+            }
+        });
+        assertThat(exception.getCause().getMessage()).isEqualTo("Programming error: field fieldXXX does not exist or is not accessible");
+    }
+
+}

--- a/src/test/java/nl/knaw/dans/validation/MutuallyExclusiveTest.java
+++ b/src/test/java/nl/knaw/dans/validation/MutuallyExclusiveTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.validation;
+
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.ValidationException;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class MutuallyExclusiveTest {
+
+    @MutuallyExclusive(fields = { "field1", "field2" })
+    private static class TestObject {
+        private String field1;
+        private String field2;
+    }
+
+    @MutuallyExclusive(fields = { "field1", "fieldXXX" })
+    private static class TestObjectMisconfigured {
+        private String field1;
+        private String field2;
+    }
+
+    @Test
+    public void should_return_true_when_one_of_two_fields_is_null() {
+        var testObject = new TestObject();
+        testObject.field1 = "value";
+        testObject.field2 = null;
+
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = factory.getValidator();
+            Set<ConstraintViolation<TestObject>> violations = validator.validate(testObject);
+
+            assertThat(violations).isEmpty();
+        }
+    }
+
+    @Test
+    public void should_return_false_when_two_of_two_fields_are_non_null() {
+        var testObject = new TestObject();
+        testObject.field1 = "value";
+        testObject.field2 = "value";
+
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = factory.getValidator();
+            Set<ConstraintViolation<TestObject>> violations = validator.validate(testObject);
+
+            assertThat(violations).hasSize(1);
+            assertThat(violations).allMatch(v -> v.getMessage().equals("The fields [field1, field2] are mutually exclusive"));
+        }
+    }
+
+    @Test
+    public void should_return_true_when_two_of_two_fields_are_null() {
+        var testObject = new TestObject();
+        testObject.field1 = null;
+        testObject.field2 = null;
+
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = factory.getValidator();
+            Set<ConstraintViolation<TestObject>> violations = validator.validate(testObject);
+
+            assertThat(violations).isEmpty();
+        }
+    }
+
+    @Test
+    public void should_throw_exception_when_field_does_not_exist() {
+        var testObject = new TestObjectMisconfigured();
+        testObject.field1 = "value";
+
+        var exception = assertThrows(ValidationException.class, () -> {
+            try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+                Validator validator = factory.getValidator();
+                validator.validate(testObject);
+            }
+        });
+        assertThat(exception.getCause().getMessage()).isEqualTo("Programming error: field fieldXXX does not exist or is not accessible");
+    }
+
+}

--- a/src/test/java/nl/knaw/dans/validation/SwordTokenTest.java
+++ b/src/test/java/nl/knaw/dans/validation/SwordTokenTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.validation;
+
+import org.junit.jupiter.api.Test;
+
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SwordTokenTest {
+
+    @Test
+    public void should_return_false_if_no_sword_prefix() {
+        var testObject = new Object() {
+
+            @SwordToken
+            private final String swordToken = "a8348df2-768d-4995-acc8-0ea878b05078";
+        };
+
+        // Validate
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = factory.getValidator();
+            var violations = validator.validate(testObject);
+            assertThat(violations).hasSize(1);
+            assertThat(violations).allMatch(v -> v.getMessage().equals("SWORD token must start with 'sword:' prefix"));
+        }
+    }
+
+    @Test
+    public void should_return_false_if_invalid_uuid() {
+        var testObject = new Object() {
+
+            @SwordToken
+            private final String swordToken = "sword:not-a-uuid";
+        };
+
+        // Validate
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = factory.getValidator();
+            var violations = validator.validate(testObject);
+            assertThat(violations).hasSize(1);
+            assertThat(violations).allMatch(v -> v.getMessage().equals("SWORD token must contain a valid UUID after the 'sword:' prefix"));
+        }
+    }
+
+    @Test
+    public void should_return_true_if_valid_sword_token() {
+        var testObject = new Object() {
+
+            @SwordToken
+            private final String swordToken = "sword:a8348df2-768d-4995-acc8-0ea878b05078";
+        };
+
+        // Validate
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = factory.getValidator();
+            var violations = validator.validate(testObject);
+            assertThat(violations).isEmpty();
+        }
+    }
+    
+    @Test
+    public void should_return_true_if_null() {
+        var testObject = new Object() {
+
+            @SwordToken
+            private final String swordToken = null;
+        };
+
+        // Validate
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = factory.getValidator();
+            var violations = validator.validate(testObject);
+            assertThat(violations).isEmpty();
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes DD-1492

# Description of changes
* Added more validators:
  * `AtLeastOneOf`: validates that at least one of the fields in the provided list is non-null.
  * `MutuallyExclusive`:  validates that not more than one of the fields in the provided list is non-null.
  * `SwordToken`:  validate that the format of a String is `sword:<uuid>`.
* Extended the allowed usage of `UrnUuid` to function parameters.

# How to test
See unit tests.


# Notify
@DANS-KNAW/core-systems
